### PR TITLE
Added an oilpaint filter for simplecv-js

### DIFF
--- a/app/models/Image.coffee
+++ b/app/models/Image.coffee
@@ -1112,21 +1112,21 @@ module.exports = class Image extends Model
     for i in [radius..@height-radius-1]
       for j in [radius..@width-radius-1]
         intensityCount = []; averageR = []; averageG = []; averageB = []
-        for k in [0..intensityLevels-1]
+        for k in [0..intensityLevels]
           intensityCount.push 0
           averageR.push 0 
           averageG.push 0
           averageB.push 0
         for p in [(-radius)..radius]
           for q in [(-radius)..radius]
-            d = Math.round (red[i+p][j+q]+green[i+p][j+q]+blue[i+p][j+q])/3
-            curIntensity = Math.round ((d/256)*intensityLevels) 
+            d = (red[i+p][j+q]+green[i+p][j+q]+blue[i+p][j+q])/3
+            curIntensity = Math.round ((d/255.0)*intensityLevels) 
             intensityCount[curIntensity]++
             averageR[curIntensity]+= red[i+p][j+q]
             averageG[curIntensity]+= green[i+p][j+q]
             averageB[curIntensity]+= blue[i+p][j+q]
         curMax = intensityCount[0]
-        for r in [0..intensityLevels-1]
+        for r in [0..intensityLevels]
           if(intensityCount[r] > curMax)
             curMax = intensityCount[r]
             maxIndex = r

--- a/app/models/Image.coffee
+++ b/app/models/Image.coffee
@@ -1082,6 +1082,64 @@ module.exports = class Image extends Model
       out.data[i+1] = g
       out.data[i+2] = b
       i+=4
+    return new Image(out)
+    
+  #This method changes an Image into an oilpainting.More info at http://www.codeproject.com/Articles/471994/OilPaintEffect
+  #Don't keep the radius more than 4. As you increase the radius the cost will increase
+  #This Algorithm is slow , so lookout a little longer than usual for the result 
+  oilpaint:(radius = 2,intensityLevels = 20)=>
+    red = []; green = []; blue = []
+    finalRed = []; finalGreen = []; finalBlue = []
+    out = @getArray()
+    x = []; y = []; z = []; f = [];g = []; h =[]
+    a = 0;
+    for i in [0..@height-1]
+      for j in [0..@width-1]
+        x.push out.data[a]
+        f.push out.data[a]
+        y.push out.data[a+1]
+        g.push out.data[a+1]
+        z.push out.data[a+2]
+        h.push out.data[a+2]
+        a+=4
+      red.push x
+      finalRed.push f
+      green.push y
+      finalGreen.push g
+      blue.push z
+      finalBlue.push h
+      x = []; y = []; z = []; f = [];g = []; h =[]
+    for i in [radius..@height-radius-1]
+      for j in [radius..@width-radius-1]
+        intensityCount = []; averageR = []; averageG = []; averageB = []
+        for k in [0..intensityLevels-1]
+          intensityCount.push 0
+          averageR.push 0 
+          averageG.push 0
+          averageB.push 0
+        for p in [(-radius)..radius]
+          for q in [(-radius)..radius]
+            d = Math.round (red[i+p][j+q]+green[i+p][j+q]+blue[i+p][j+q])/3
+            curIntensity = Math.round ((d/256)*intensityLevels) 
+            intensityCount[curIntensity]++
+            averageR[curIntensity]+= red[i+p][j+q]
+            averageG[curIntensity]+= green[i+p][j+q]
+            averageB[curIntensity]+= blue[i+p][j+q]
+        curMax = intensityCount[0]
+        for r in [0..intensityLevels-1]
+          if(intensityCount[r] > curMax)
+            curMax = intensityCount[r]
+            maxIndex = r
+        finalRed[i][j] = averageR[maxIndex] / curMax
+        finalGreen[i][j] = averageG[maxIndex] / curMax
+        finalBlue[i][j] = averageB[maxIndex] / curMax
+    b = 0
+    for i in [0..@height-1]
+      for j in [0..@width-1]
+        out.data[b] = finalRed[i][j]
+        out.data[b+1] = finalGreen[i][j]
+        out.data[b+2] = finalBlue[i][j]
+        b+=4
     return new Image(out)    
 
 

--- a/app/models/Image.coffee
+++ b/app/models/Image.coffee
@@ -1084,7 +1084,7 @@ module.exports = class Image extends Model
       i+=4
     return new Image(out)
     
-  #This method changes an Image into an oilpainting.More info at http://www.codeproject.com/Articles/471994/OilPaintEffect
+  #This method changes an Image into an oilpainting.More info at http://supercomputingblog.com/graphics/oil-painting-algorithm/
   #Don't keep the radius more than 4. As you increase the radius the cost will increase
   #This Algorithm is slow , so lookout a little longer than usual for the result 
   oilpaint:(radius = 2,intensityLevels = 20)=>


### PR DESCRIPTION
I've been checking out some Image manipulation filters and I came across this filter which turns an image into an oilpainting of itself. I thought it would be fun to implement it in SimpleCV-js. But there are some limitations to the algorithm.

1) Since we compare a pixel with its neighbourhood of given radius. There are a large number of comparisons so the algorithm is a little slow.

2) For intensity levels  20 is a good number. you might want to use that.

3) keep the radius between 2 and 4 . if you increase it then the method will take a lot of time

4) since it takes time to execute you might want to wait a while than usual to see the result :)     

I think it would be very cool if we could add a progress bar which can show the progress for these type of operations which take longtime. I could do it with some help. Any ideas? 
